### PR TITLE
Improve LCP with lazy loading and remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "framer-motion": "^12.23.26",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "react": "19.2.3",
@@ -4258,33 +4257,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.23.26",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.26.tgz",
-      "integrity": "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.23.23",
-        "motion-utils": "^12.23.6",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5617,21 +5589,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.23.23",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
-      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.23.6"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
-      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.23.26",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "react": "19.2.3",

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,19 +1,41 @@
 import type { Metadata } from 'next';
-import {
-  Hero,
-  ProblemSolution,
-  GuideCredentials,
-  HowItWorks,
-  MoneyBackGuarantee,
-  CourseBundles,
-  Features,
-  TRECData,
-  Testimonials,
-  CostOfFailure,
-  SuccessStakes,
-  SubscriptionCallout,
-  CTA,
-} from '@/components/sections';
+import dynamic from 'next/dynamic';
+import { Hero, CTA } from '@/components/sections';
+
+// Lazy-load below-the-fold sections for better LCP
+const ProblemSolution = dynamic(() =>
+  import('@/components/sections/problem-solution').then((m) => m.ProblemSolution)
+);
+const GuideCredentials = dynamic(() =>
+  import('@/components/sections/guide-credentials').then((m) => m.GuideCredentials)
+);
+const HowItWorks = dynamic(() =>
+  import('@/components/sections/how-it-works').then((m) => m.HowItWorks)
+);
+const MoneyBackGuarantee = dynamic(() =>
+  import('@/components/sections/money-back-guarantee').then((m) => m.MoneyBackGuarantee)
+);
+const CourseBundles = dynamic(() =>
+  import('@/components/sections/course-bundles').then((m) => m.CourseBundles)
+);
+const Features = dynamic(() =>
+  import('@/components/sections/features').then((m) => m.Features)
+);
+const TRECData = dynamic(() =>
+  import('@/components/sections/trec-data').then((m) => m.TRECData)
+);
+const Testimonials = dynamic(() =>
+  import('@/components/sections/testimonials').then((m) => m.Testimonials)
+);
+const CostOfFailure = dynamic(() =>
+  import('@/components/sections/cost-of-failure').then((m) => m.CostOfFailure)
+);
+const SuccessStakes = dynamic(() =>
+  import('@/components/sections/success-stakes').then((m) => m.SuccessStakes)
+);
+const SubscriptionCallout = dynamic(() =>
+  import('@/components/sections/subscription-callout').then((m) => m.SubscriptionCallout)
+);
 
 export const metadata: Metadata = {
   title: 'The Inspection Academy | Texas Home Inspector Training',


### PR DESCRIPTION
## Summary
- Remove framer-motion (14.8 KiB) - was installed but never used
- Lazy-load 11 below-the-fold homepage sections using Next.js dynamic imports
- Keep Hero and CTA eager for critical rendering path

## Expected Impact
- Reduce initial JS bundle by 40-55 KiB
- Improve LCP from 3.9s toward 2.5s target
- Increase Performance score from 86 toward 90+

## Test plan
- [ ] Verify homepage loads correctly
- [ ] Scroll through homepage - sections should load smoothly
- [ ] Run PageSpeed Insights after deploy
- [ ] Verify LCP improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed framer-motion dependency from the project

* **Refactor**
  * Optimized page loading by implementing on-demand section loading for below-the-fold content, reducing initial page render time while maintaining the same page structure and content order

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->