### PR TITLE
Add phone-focused CTAs and sticky mobile footer

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,4 @@
-import { Header, Footer } from '@/components/layout';
+import { Header, Footer, StickyCTA } from '@/components/layout';
 import { AnalyticsProvider } from '@/components/providers';
 
 export default function MainLayout({
@@ -11,6 +11,7 @@ export default function MainLayout({
       <Header />
       <main className="min-h-screen">{children}</main>
       <Footer />
+      <StickyCTA />
     </AnalyticsProvider>
   );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,9 +1,16 @@
+'use client';
+
 import Link from 'next/link';
 import { Phone, Mail, Calendar } from 'lucide-react';
 import { Container } from './container';
 import { SITE_CONFIG, FOOTER_LINKS } from '@/lib/constants';
+import { trackEvent } from '@/lib/analytics';
 
 export function Footer() {
+  const handlePhoneClick = () => {
+    trackEvent('phone_call', { location: 'footer' });
+  };
+
   return (
     <footer className="bg-gray-900 text-gray-300">
       <Container>
@@ -69,6 +76,7 @@ export function Footer() {
                 <li>
                   <a
                     href={`tel:${SITE_CONFIG.phone}`}
+                    onClick={handlePhoneClick}
                     className="flex items-center text-sm hover:text-white transition-colors"
                   >
                     <Phone className="mr-2 h-4 w-4" />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,24 +5,20 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { Menu, X, Phone } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/sheet';
 import { Container } from './container';
 import { NAV_ITEMS, SITE_CONFIG } from '@/lib/constants';
-import { trackScheduleCall, trackEvent } from '@/lib/analytics';
+import { trackEvent } from '@/lib/analytics';
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false);
-
-  const handleScheduleClick = () => {
-    trackScheduleCall('header');
-  };
 
   const handlePhoneClick = () => {
     trackEvent('phone_call', { location: 'header' });
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+    <header className="sticky top-0 z-50 w-full border-b bg-white">
       <Container>
         <div className="flex h-20 items-center justify-between">
           {/* Logo */}
@@ -52,30 +48,31 @@ export function Header() {
 
           {/* Desktop CTA */}
           <div className="hidden md:flex items-center space-x-4">
-            <a
-              href={`tel:${SITE_CONFIG.phone}`}
-              onClick={handlePhoneClick}
-              className="flex items-center text-sm text-gray-600 hover:text-primary"
-            >
-              <Phone className="mr-2 h-4 w-4" />
-              {SITE_CONFIG.phone}
-            </a>
-            <Button asChild onClick={handleScheduleClick}>
-              <a href={SITE_CONFIG.links.scheduleCall} target="_blank" rel="noopener noreferrer">
-                Book an Online Meeting
+            <Button asChild onClick={handlePhoneClick}>
+              <a href={`tel:${SITE_CONFIG.phone}`}>
+                <Phone className="mr-2 h-4 w-4" />
+                {SITE_CONFIG.phone}
               </a>
             </Button>
           </div>
 
-          {/* Mobile Menu */}
-          <Sheet open={isOpen} onOpenChange={setIsOpen}>
-            <SheetTrigger asChild className="md:hidden">
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-                <span className="sr-only">Toggle menu</span>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-[300px] sm:w-[400px]">
+          {/* Mobile CTA + Menu */}
+          <div className="flex md:hidden items-center gap-2">
+            <Button asChild onClick={handlePhoneClick}>
+              <a href={`tel:${SITE_CONFIG.phone}`}>
+                <Phone className="mr-2 h-4 w-4" />
+                Call Now
+              </a>
+            </Button>
+            <Sheet open={isOpen} onOpenChange={setIsOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <Menu className="h-6 w-6" />
+                  <span className="sr-only">Toggle menu</span>
+                </Button>
+              </SheetTrigger>
+            <SheetContent side="right" className="w-[300px] sm:w-[400px] px-6">
+              <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
               <nav className="flex flex-col space-y-4 mt-8">
                 {NAV_ITEMS.map((item) => (
                   <Link
@@ -88,22 +85,16 @@ export function Header() {
                   </Link>
                 ))}
                 <hr className="my-4" />
-                <a
-                  href={`tel:${SITE_CONFIG.phone}`}
-                  onClick={handlePhoneClick}
-                  className="flex items-center text-lg text-gray-600 hover:text-primary"
-                >
-                  <Phone className="mr-2 h-5 w-5" />
-                  {SITE_CONFIG.phone}
-                </a>
-                <Button asChild className="w-full mt-4" onClick={handleScheduleClick}>
-                  <a href={SITE_CONFIG.links.scheduleCall} target="_blank" rel="noopener noreferrer">
-                    Book an Online Meeting
+                <Button asChild className="w-full" onClick={handlePhoneClick}>
+                  <a href={`tel:${SITE_CONFIG.phone}`}>
+                    <Phone className="mr-2 h-5 w-5" />
+                    {SITE_CONFIG.phone}
                   </a>
                 </Button>
               </nav>
             </SheetContent>
-          </Sheet>
+            </Sheet>
+          </div>
         </div>
       </Container>
     </header>

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -2,5 +2,6 @@ export { Header } from './header';
 export { Footer } from './footer';
 export { Container } from './container';
 export { Section } from './section';
+export { StickyCTA } from './sticky-cta';
 export { LandingPageHeader } from './landing-page-header';
 export { LandingPageFooter } from './landing-page-footer';

--- a/src/components/layout/sticky-cta.tsx
+++ b/src/components/layout/sticky-cta.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Phone } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { SITE_CONFIG } from '@/lib/constants';
+import { trackScheduleCall, trackEvent } from '@/lib/analytics';
+
+export function StickyCTA() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      // Show after scrolling 500px
+      const shouldShow = window.scrollY > 500;
+      setIsVisible(shouldShow);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const handleScheduleClick = () => {
+    trackScheduleCall('sticky_cta');
+  };
+
+  const handleCallClick = () => {
+    trackEvent('phone_call', { location: 'sticky_cta' });
+  };
+
+  return (
+    <div
+      className={`fixed bottom-0 left-0 right-0 z-40 md:hidden transition-transform duration-300 ${
+        isVisible ? 'translate-y-0' : 'translate-y-full'
+      }`}
+    >
+      <div className="bg-white border-t shadow-lg px-4 py-3">
+        <div className="flex items-center gap-3">
+          {/* Call Button */}
+          <Button
+            size="sm"
+            variant="outline"
+            className="flex-shrink-0 px-3"
+            asChild
+            onClick={handleCallClick}
+          >
+            <a href={`tel:${SITE_CONFIG.phone}`}>
+              <Phone className="h-4 w-4" />
+            </a>
+          </Button>
+
+          {/* Text */}
+          <div className="flex-1 min-w-0">
+            <div className="font-semibold text-gray-900 text-sm">
+              Ready to get started?
+            </div>
+            <div className="text-xs text-gray-500 truncate">
+              Talk with an expert today
+            </div>
+          </div>
+
+          {/* Schedule Meeting Button */}
+          <Button size="sm" className="flex-shrink-0" asChild onClick={handleScheduleClick}>
+            <a
+              href={SITE_CONFIG.links.scheduleCall}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Schedule a Meeting
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Header CTA changed from "Book Meeting" to "Call Now" button (always visible on mobile)
- Header background now solid white (removed translucent/blur effect)
- Added padding to hamburger menu for better spacing
- Fixed accessibility warning (added SheetTitle for screen readers)
- Added phone_call event tracking to footer phone link
- New sticky mobile CTA bar with phone button + "Schedule a Meeting" (appears after 500px scroll)

## Test plan
- [ ] Verify "Call Now" button visible in mobile header
- [ ] Verify hamburger menu has proper padding
- [ ] Verify sticky CTA appears on mobile after scrolling
- [ ] Verify all phone CTAs trigger `phone_call` event in dataLayer
- [ ] Verify no accessibility warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sticky call-to-action bar on mobile after scrolling.
  * Added dedicated "Call Now" button in mobile header navigation.

* **Updates**
  * Simplified header design with solid background styling.
  * Enhanced phone call tracking for analytics across footer and header.
  * Updated mobile navigation with improved call-to-action placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->